### PR TITLE
Linux upgrade

### DIFF
--- a/binjr-core/src/main/java/eu/binjr/core/preferences/UpdateManager.java
+++ b/binjr-core/src/main/java/eu/binjr/core/preferences/UpdateManager.java
@@ -34,8 +34,6 @@ import org.apache.logging.log4j.Logger;
 import org.controlsfx.control.Notifications;
 import org.controlsfx.control.action.Action;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ ext.JLINK_ADD_MODULES = "javafx.controls," +
         "${IS_WINDOWS ? ",jdk.crypto.mscapi" : ""}"
 
 ext.DISTRIBUTION_NAME = "${project.name}-${BINJR_VERSION}_${OS_FAMILY}-${OS_ARCH}"
-ext.DISTRIBUTION_PATH = "${buildDir}/distributions/${DISTRIBUTION_NAME}"
+ext.DISTRIBUTION_ROOT = "${buildDir}/distributions/${DISTRIBUTION_NAME}"
+ext.DISTRIBUTION_PATH = IS_WINDOWS ? "${DISTRIBUTION_ROOT}" : "${DISTRIBUTION_ROOT}/${BINJR_VERSION}"
 
 ext."signing.keyId" = System.getenv('GPG_KEY_NAME')
 ext."signing.secretKeyRingFile" = "${System.getProperty("user.home")}/.gnupg/secring.gpg"
@@ -346,16 +347,24 @@ task listPackageContent(type: Exec) {
 }
 
 task packageDistributionZip(type: Zip) {
-    from DISTRIBUTION_PATH
+    from DISTRIBUTION_ROOT
     destinationDir buildDir
     archiveName "${DISTRIBUTION_NAME}.zip"
 }
 
-task packageDistributionTar(type: Tar, dependsOn: [listPackageContent]) {
+task compressDistributionTar(type: Tar, dependsOn: [listPackageContent]) {
     compression Compression.GZIP
-    from DISTRIBUTION_PATH
+    from DISTRIBUTION_ROOT
     destinationDir buildDir
     archiveName "${DISTRIBUTION_NAME}.tar.gz"
+}
+
+task packageDistributionTar(type: Exec, dependsOn: [listPackageContent]) {
+        workingDir DISTRIBUTION_ROOT
+	commandLine = [
+		"ln", "-s", "${BINJR_VERSION}/binjr", "binjr"
+	]
+        finalizedBy(compressDistributionTar)
 }
 
 task wixRunHeat(type: Exec, dependsOn: [packageDistributionZip]) {

--- a/build.gradle
+++ b/build.gradle
@@ -339,9 +339,9 @@ task createRuntimeImage(type: Exec, dependsOn: [downloadAndUnzipFile]) {
 task listPackageContent(type: Exec) {
     workingDir DISTRIBUTION_PATH
     commandLine = [
-            "bash",
-            "-c",
-            'du -a | grep -oi  \\.\\/.*\$ > .installed'
+            "find",
+            "-mindepth", "1",
+            "-fprintf", ".installed", "%P\n"
     ]
 }
 

--- a/distribution/platforms/linux/binjr
+++ b/distribution/platforms/linux/binjr
@@ -1,25 +1,11 @@
-#!/bin/sh
+#! /bin/sh
 
-# resolve links - $0 may be a softlink
-PRG="$0"
-
-while [ -h "$PRG" ]; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
-
-PRGDIR=`dirname "$PRG"`
-BASEDIR=`cd "$PRGDIR" >/dev/null; pwd`
+BASEDIR="$(dirname "$(readlink -f "$0")")"
 
 JAVACMD="$BASEDIR/runtime/bin/java"
 
 exec $JAVACMD \
-  -splash:"./resources/images/splashscreen.png" \
+  -splash:"$BASEDIR/resources/images/splashscreen.png" \
   -cp "$BASEDIR/libs/*:$BASEDIR/plugins/*" \
   -Xmx2048M \
   -XX:+UnlockExperimentalVMOptions \


### PR DESCRIPTION
This implements atomic upgrades of binjr on Linux. This is plugged for macOS as well and hopefully it works, but I can't test, so expect some glitches with GNU-specific flags that won't work on macOS' BSD userland.

The less complex non-atomic upgrade code is still in the history (19f4a6c).

I have two suggestions for later:
 * sign the release tarball and check the signature before upgrading (solves the integrity issue for both download problems and MITM);
 * start downloading the release tarball in the background as soon as the user decides to upgrade on exit (so that exiting is as fast as possible) — with the current atomic upgrade code, we could go as far as actually installing the new release in the background as well, just leaving the atomic symlink replacement and cleanup to do on exit.