### PR TITLE
Don't attempt to validate the empty string as an URI

### DIFF
--- a/binjr-core/src/main/java/eu/binjr/core/dialogs/DataAdapterDialog.java
+++ b/binjr-core/src/main/java/eu/binjr/core/dialogs/DataAdapterDialog.java
@@ -118,7 +118,11 @@ public abstract class DataAdapterDialog<T> extends Dialog<Collection<DataAdapter
                 updateUriAutoCompletionBinding();
             }
         });
-        uriField.getSelectionModel().selectedItemProperty().addListener((obs, oldText, uri) -> validateUri(uri));
+        uriField.getSelectionModel().selectedItemProperty().addListener((obs, oldText, uri) -> {
+            if (!uri.isEmpty()) {
+                validateUri(uri);
+            }
+        });
         timezoneField = (TextField) parent.lookup("#timezoneField");
         timezoneLabel = (Label) parent.lookup("#timeZoneLabel");
         timezoneField.setManaged(showTimezone);


### PR DESCRIPTION
This prevents data adapters from trying to do “smart” things on the current
working directory as if it was a valid data source (which it most probably
isn't most of the time).

At least on Linux, JavaFX triggers a change event when clicking on the “browse”
button, so this actually happened pretty much every time.